### PR TITLE
fix: conformidade com política de Declarações Enganosas do Google Play

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="br.com.sthaynny.habilitacao_quiz">
    <uses-permission android:name="com.android.vending.BILLING" />
+   <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="https" />
+        </intent>
+   </queries>
    <application
         android:label="Habilitação Quiz"
         android:name="${applicationName}"

--- a/google_play/store_listing_en-US.txt
+++ b/google_play/store_listing_en-US.txt
@@ -1,0 +1,23 @@
+Driving License Quiz is an educational question-and-answer game to help users practice content related to Brazilian traffic laws. The app covers topics such as legislation, defensive driving, basic mechanics, first aid, and environment.
+
+LEGAL NOTICE — PLEASE READ CAREFULLY
+
+This app does NOT represent, is NOT affiliated with, sponsored by, or approved by any government entity, including SENATRAN (formerly DENATRAN) or any state DETRAN. The content is exclusively educational and does NOT replace official courses, DETRAN materials, or the theoretical CNH exam.
+
+OFFICIAL GOVERNMENT INFORMATION SOURCES
+
+The questions are based on educational content about traffic. For official and up-to-date information, please visit:
+
+• SENATRAN (National Traffic Secretariat):
+https://www.gov.br/transportes/pt-br/assuntos/transito/senatran
+
+• Brazilian Traffic Code (Law No. 9,503/1997):
+https://www.planalto.gov.br/ccivil_03/leis/l9503.htm
+
+• Ministry of Transport:
+https://www.gov.br/transportes
+
+App features:
+• Category quizzes and mock exams
+• Performance history
+• Study aid for the theoretical CNH exam

--- a/google_play/store_listing_pt-BR.txt
+++ b/google_play/store_listing_pt-BR.txt
@@ -1,0 +1,23 @@
+Habilitação Quiz é um jogo educativo de perguntas e respostas para ajudar você a praticar conteúdos relacionados ao trânsito brasileiro. O app aborda temas como legislação, direção defensiva, mecânica básica, primeiros socorros e meio ambiente.
+
+AVISO LEGAL — LEIA COM ATENÇÃO
+
+Este aplicativo NÃO representa, NÃO é afiliado, patrocinado ou aprovado por qualquer entidade governamental, incluindo a SENATRAN (antiga DENATRAN) ou qualquer DETRAN estadual. O conteúdo é exclusivamente educacional e NÃO substitui cursos oficiais, materiais do DETRAN ou a prova teórica da CNH.
+
+FONTES OFICIAIS DE INFORMAÇÕES GOVERNAMENTAIS
+
+As questões são baseadas em conteúdo educacional sobre trânsito. Para informações oficiais e atualizadas, consulte:
+
+• SENATRAN (Secretaria Nacional de Trânsito):
+https://www.gov.br/transportes/pt-br/assuntos/transito/senatran
+
+• Código de Trânsito Brasileiro (Lei nº 9.503/1997):
+https://www.planalto.gov.br/ccivil_03/leis/l9503.htm
+
+• Ministério dos Transportes:
+https://www.gov.br/transportes
+
+Recursos do app:
+• Quizzes por categoria e simulados
+• Histórico de desempenho
+• Estudo para a prova teórica da CNH

--- a/lib/app/features/home/presentation/components/app_bar.dart
+++ b/lib/app/features/home/presentation/components/app_bar.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:habilitacao_quiz/app/features/routes/routes.dart';
 import 'package:habilitacao_quiz/core/styles/app_colors.dart';
 import 'package:habilitacao_quiz/core/styles/app_font_styles.dart';
 import 'package:habilitacao_quiz/core/styles/app_gradients.dart';
@@ -33,16 +35,26 @@ class AppBarWidget extends StatelessWidget implements PreferredSizeWidget {
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                Semantics(
-                  header: true,
-                  child: Text.rich(
-                    TextSpan(
-                      text: 'Habilitação Quiz',
-                      style: AppFontStyle.headline24Bold.setColor(
-                        AppColors.white,
+                Expanded(
+                  child: Semantics(
+                    header: true,
+                    child: Text.rich(
+                      TextSpan(
+                        text: 'Habilitação Quiz',
+                        style: AppFontStyle.headline24Bold.setColor(
+                          AppColors.white,
+                        ),
                       ),
                     ),
                   ),
+                ),
+                IconButton(
+                  icon: const Icon(
+                    Icons.info_outline,
+                    color: AppColors.white,
+                  ),
+                  tooltip: 'Aviso legal',
+                  onPressed: () => Get.toNamed(Routes.legalNotice),
                 ),
                 Container(
                   height: 90,

--- a/lib/app/features/legal/presentation/legal_notice_screen.dart
+++ b/lib/app/features/legal/presentation/legal_notice_screen.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:habilitacao_quiz/core/components/button.dart';
+import 'package:habilitacao_quiz/core/constants/government_sources.dart';
+import 'package:habilitacao_quiz/core/mixins/pop_up_mixin.dart';
+import 'package:habilitacao_quiz/core/styles/app_styles.dart';
+import 'package:habilitacao_quiz/core/styles/spacing_stack.dart';
+import 'package:habilitacao_quiz/core/utils/strings.dart';
+import 'package:habilitacao_quiz/core/utils/url_launcher_helper.dart';
+
+class LegalNoticeScreen extends StatefulWidget {
+  const LegalNoticeScreen({super.key});
+
+  @override
+  State<LegalNoticeScreen> createState() => _LegalNoticeScreenState();
+}
+
+class _LegalNoticeScreenState extends State<LegalNoticeScreen> with PopUpMixin {
+  Future<void> _openSource(GovernmentSource source) async {
+    final opened = await openExternalUrl(source.url);
+    if (!opened && mounted) popUpErro();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          Strings.avisoLegal,
+          style: AppFontStyle.headline20Bold,
+        ),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: Get.back,
+          tooltip: Strings.voltar,
+        ),
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: EdgeInsets.all(AppSpacingStack.xSmall.value),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _DisclaimerCard(),
+              SizedBox(height: AppSpacingStack.xSmall.value),
+              Text(
+                Strings.fontesOficiais,
+                style: AppFontStyle.headline20Bold,
+              ),
+              SizedBox(height: AppSpacingStack.nano.value),
+              Text(
+                Strings.fontesOficiaisDescricao,
+                style: AppFontStyle.body14Regular.setColor(AppColors.grey),
+              ),
+              SizedBox(height: AppSpacingStack.xSmall.value),
+              ...GovernmentSources.list.map(
+                (source) => _SourceTile(
+                  source: source,
+                  onTap: () => _openSource(source),
+                ),
+              ),
+              SizedBox(height: AppSpacingStack.xSmall.value),
+              AppButton.primary(
+                Strings.voltar,
+                expanded: true,
+                onPressed: Get.back,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DisclaimerCard extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: EdgeInsets.all(AppSpacingStack.xSmall.value),
+      decoration: BoxDecoration(
+        color: AppColors.lightPurple.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Icon(Icons.info_outline, color: AppColors.purple),
+              SizedBox(width: AppSpacingStack.nano.value),
+              Text(
+                Strings.avisoLegal,
+                style: AppFontStyle.body16Bold.setColor(AppColors.purple),
+              ),
+            ],
+          ),
+          SizedBox(height: AppSpacingStack.nano.value),
+          Text(
+            Strings.avisoLegalTexto,
+            style: AppFontStyle.body14Regular,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SourceTile extends StatelessWidget {
+  const _SourceTile({
+    required this.source,
+    required this.onTap,
+  });
+
+  final GovernmentSource source;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(bottom: AppSpacingStack.nano.value),
+      child: Material(
+        color: AppColors.white,
+        borderRadius: BorderRadius.circular(12),
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(12),
+          child: Container(
+            width: double.infinity,
+            padding: EdgeInsets.all(AppSpacingStack.xSmall.value),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(color: AppColors.border),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  source.title,
+                  style: AppFontStyle.body16Bold,
+                ),
+                SizedBox(height: AppSpacingStack.quarck.value),
+                Text(
+                  source.description,
+                  style: AppFontStyle.body14Regular.setColor(AppColors.grey),
+                ),
+                SizedBox(height: AppSpacingStack.nano.value),
+                Text(
+                  source.url,
+                  style: AppFontStyle.body14Regular.setColor(AppColors.blue),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/app/features/routes/routes.dart
+++ b/lib/app/features/routes/routes.dart
@@ -2,5 +2,6 @@ abstract class Routes {
   static const home = '/home';
   static const questionario = '/questionario';
   static const resultado = '/resultado';
+  static const legalNotice = '/aviso-legal';
   static const init = '/';
 }

--- a/lib/app/my_app.dart
+++ b/lib/app/my_app.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:get/get.dart';import 'package:habilitacao_quiz/app/features/home/presentation/home_screen.dart';
+import 'package:get/get.dart';
+import 'package:habilitacao_quiz/app/features/home/presentation/home_screen.dart';
+import 'package:habilitacao_quiz/app/features/legal/presentation/legal_notice_screen.dart';
 import 'package:habilitacao_quiz/app/features/questionario/presentation/questionario_screen.dart';
 import 'package:habilitacao_quiz/app/features/resultado/presentation/resultado_screen.dart';
 import 'package:habilitacao_quiz/app/features/routes/routes.dart';
@@ -48,6 +50,10 @@ class MyApp extends StatelessWidget {
           transition: Transition.fadeIn,
           transitionDuration: const Duration(seconds: 2),
           showCupertinoParallax: false,
+        ),
+        GetPage(
+          name: Routes.legalNotice,
+          page: () => const LegalNoticeScreen(),
         ),
       ],
     );

--- a/lib/core/constants/government_sources.dart
+++ b/lib/core/constants/government_sources.dart
@@ -1,0 +1,40 @@
+class GovernmentSource {
+  const GovernmentSource({
+    required this.title,
+    required this.url,
+    required this.description,
+  });
+
+  final String title;
+  final String url;
+  final String description;
+}
+
+abstract class GovernmentSources {
+  static const senatran = GovernmentSource(
+    title: 'SENATRAN',
+    url: 'https://www.gov.br/transportes/pt-br/assuntos/transito/senatran',
+    description:
+        'Secretaria Nacional de Trânsito — órgão federal responsável pelas normas de trânsito no Brasil.',
+  );
+
+  static const codigoTransitoBrasileiro = GovernmentSource(
+    title: 'Código de Trânsito Brasileiro (Lei nº 9.503/1997)',
+    url: 'https://www.planalto.gov.br/ccivil_03/leis/l9503.htm',
+    description:
+        'Legislação federal que rege o trânsito de veículos terrestres no Brasil.',
+  );
+
+  static const ministerioTransportes = GovernmentSource(
+    title: 'Ministério dos Transportes',
+    url: 'https://www.gov.br/transportes',
+    description:
+        'Portal oficial do Ministério dos Transportes do Governo Federal.',
+  );
+
+  static const list = [
+    senatran,
+    codigoTransitoBrasileiro,
+    ministerioTransportes,
+  ];
+}

--- a/lib/core/utils/strings.dart
+++ b/lib/core/utils/strings.dart
@@ -26,6 +26,12 @@ abstract class Strings {
   static const voltarInicio = 'Voltar ao início';
   static const historico = 'Histórico';
   static const quizzes = 'Quizzes';
+  static const avisoLegal = 'Aviso legal';
+  static const fontesOficiais = 'Fontes oficiais';
+  static const fontesOficiaisDescricao =
+      'As questões deste app são baseadas em conteúdo educacional sobre trânsito. Consulte sempre as fontes oficiais abaixo para informações atualizadas.';
+  static const avisoLegalTexto =
+      'Este aplicativo é independente e não representa, não é afiliado, patrocinado ou aprovado por qualquer entidade governamental, incluindo a SENATRAN (antiga DENATRAN) ou qualquer DETRAN estadual. O conteúdo é exclusivamente educacional e não substitui cursos oficiais, materiais do DETRAN ou a prova teórica da CNH.';
 
   static const comeceEstudosVizualizarProgresso =
       'Comece os estudos para visualizar seu progresso!';

--- a/lib/core/utils/url_launcher_helper.dart
+++ b/lib/core/utils/url_launcher_helper.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/foundation.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+Future<bool> openExternalUrl(String url) async {
+  final uri = Uri.parse(url);
+  try {
+    return await launchUrl(uri, mode: LaunchMode.externalApplication);
+  } catch (error, stackTrace) {
+    debugPrint('Failed to open $url: $error\n$stackTrace');
+    return false;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: habilitacao_quiz
 description: Um projeto para ajudar as pessoas que querem tirar sua CNH.
-version: 1.9.3+38
+version: 1.9.4+39
 
 environment:
   sdk: ">=3.10.4 <4.0.0"
@@ -22,6 +22,7 @@ dependencies:
   share_plus: ^13.2.0
   shared_preferences: ^2.5.5
   path_provider: ^2.1.6
+  url_launcher: ^6.3.2
 
 dev_dependencies:
   build_runner: ^2.15.0

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1,6 +1,5 @@
 Atividades realizadas na versão:
-  - Compatibilidade edge-to-edge com Android 15 (SDK 35) via EdgeToEdge.enable;
-  - Remoção de APIs descontinuadas de barra de status/navegação no Flutter;
-  - Ajuste do AppBar para respeitar insets do sistema;
-  - Correção de overflow nos cards da home;
-  - Migração para Built-in Kotlin (Flutter 3.44);
+  - Tela de aviso legal com exoneração de responsabilidade sobre afiliação governamental;
+  - Links clicáveis para fontes oficiais (.gov.br) de informações sobre trânsito;
+  - Atualização da descrição da Play Store com disclaimer e URLs oficiais;
+  - Correção de conformidade com a política de Declarações Enganosas do Google Play.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Descrição

Corrige a violação da política de **Declarações Enganosas** do Google Play (falta de links para fontes governamentais e disclaimer de não-afiliação).

### Alterações no app (v1.9.4+39)

- Nova tela **Aviso legal** acessível pelo ícone ℹ️ na home
- Disclaimer claro de que o app **não representa** entidade governamental (SENATRAN/DETRAN)
- Links clicáveis para fontes oficiais:
  - SENATRAN: https://www.gov.br/transportes/pt-br/assuntos/transito/senatran
  - Código de Trânsito Brasileiro: https://www.planalto.gov.br/ccivil_03/leis/l9503.htm
  - Ministério dos Transportes: https://www.gov.br/transportes
- Dependência `url_launcher` e queries HTTPS no `AndroidManifest.xml`

### Textos da Play Store

Arquivos em `google_play/` com descrição completa atualizada (PT-BR e EN-US), incluindo disclaimer e URLs oficiais.

## Como publicar no Google Play Console

1. Fazer merge deste PR e gerar o bundle de release (`flutter build appbundle`)
2. Em **Presença na loja → Descrição completa**, colar o conteúdo de `google_play/store_listing_pt-BR.txt` (e equivalente em inglês se aplicável)
3. Enviar a versão **1.9.4 (39)** para revisão em produção

## Checklist

- [x] Ajustei conformidade com política do Google Play
- [x] Bump de versão (1.9.4+39)
- [x] Release notes atualizadas
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f16a9-8ed8-75f8-bfde-7dcc2e7e168c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f16a9-8ed8-75f8-bfde-7dcc2e7e168c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

